### PR TITLE
vmm_normal_va2pa added

### DIFF
--- a/core/vmm_heap.c
+++ b/core/vmm_heap.c
@@ -322,7 +322,7 @@ void* vmm_normal_va2pa(virtual_addr_t va)
 	int rc;
 	physical_addr_t pa = 0x0;
 
-	rc = heap_va2pa(&dma_heap, va, &pa);
+	rc = heap_va2pa(&normal_heap, va, &pa);
 	if (rc != VMM_OK) {
 		BUG_ON(1);
 	}

--- a/core/vmm_heap.c
+++ b/core/vmm_heap.c
@@ -317,6 +317,19 @@ int vmm_normal_heap_print_state(struct vmm_chardev *cdev)
 	return heap_print_state(&normal_heap, cdev, "Normal");
 }
 
+void* vmm_normal_va2pa(virtual_addr_t va)
+{
+	int rc;
+	physical_addr_t pa = 0x0;
+
+	rc = heap_va2pa(&dma_heap, va, &pa);
+	if (rc != VMM_OK) {
+		BUG_ON(1);
+	}
+
+	return (void*)pa;
+}
+
 int __init vmm_heap_init(void)
 {
 	int rc;

--- a/openconf.cfg
+++ b/openconf.cfg
@@ -31,4 +31,4 @@ source libs/openconf.cfg
 source drivers/openconf.cfg
 source emulators/openconf.cfg
 source tools/openconf.cfg
-source #TCDIR/tcmod/openconf.cfg
+source /work/tct/poc/tcmod/openconf.cfg

--- a/openconf.cfg
+++ b/openconf.cfg
@@ -31,4 +31,4 @@ source libs/openconf.cfg
 source drivers/openconf.cfg
 source emulators/openconf.cfg
 source tools/openconf.cfg
-source /work/tct/poc/tcmod/openconf.cfg
+source #TCDIR/tcmod/openconf.cfg


### PR DESCRIPTION
The xvisor had the prototype defined in the header but was lacking the implementation.